### PR TITLE
feat(vis): Text rendering

### DIFF
--- a/crates/dexterior-visuals/Cargo.toml
+++ b/crates/dexterior-visuals/Cargo.toml
@@ -18,6 +18,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 encase = { version = "0.6.1", features = ["nalgebra"] }
 enterpolation = "0.2.1"
 futures = "0.3.29"
+glyphon = "0.6.0"
 palette = "0.7.3"
 winit = "0.30.5"
 web-time = "0.1"

--- a/crates/dexterior-visuals/src/lib.rs
+++ b/crates/dexterior-visuals/src/lib.rs
@@ -37,4 +37,5 @@ mod render_window;
 #[doc(inline)]
 pub use render_window::{RenderWindow, WindowParams};
 
+pub use glyphon;
 pub use palette;

--- a/crates/dexterior-visuals/src/lib.rs
+++ b/crates/dexterior-visuals/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) mod pipelines;
 pub use pipelines::{
     axes::AxesParams,
     line::{CapStyle, CapsStyle, JoinStyle, LineDrawingMode, LineParams, LineWidth},
+    text::{TextAnchor, TextParams},
     ArrowParams, Painter, WireframeParams,
 };
 

--- a/crates/dexterior-visuals/src/lib.rs
+++ b/crates/dexterior-visuals/src/lib.rs
@@ -29,7 +29,7 @@ pub(crate) mod pipelines;
 pub use pipelines::{
     axes::AxesParams,
     line::{CapStyle, CapsStyle, JoinStyle, LineDrawingMode, LineParams, LineWidth},
-    text::{TextAnchor, TextParams},
+    text::{TextAnchor, TextColor, TextParams},
     ArrowParams, Painter, WireframeParams,
 };
 

--- a/crates/dexterior-visuals/src/pipelines.rs
+++ b/crates/dexterior-visuals/src/pipelines.rs
@@ -318,6 +318,7 @@ impl<'a, 'ctx: 'a> Painter<'a, 'ctx> {
         );
     }
 
+    /// Draw a custom piece of text.
     pub fn text<const POS_DIM: usize>(&mut self, text: TextParams<'_, POS_DIM>) {
         let buf = self.rend.text_pl.create_buffer(text);
         self.rend.text_pl.draw(self.ctx, self.camera, &[&buf]);

--- a/crates/dexterior-visuals/src/pipelines.rs
+++ b/crates/dexterior-visuals/src/pipelines.rs
@@ -321,7 +321,12 @@ impl<'a, 'ctx: 'a> Painter<'a, 'ctx> {
     /// Draw a custom piece of text.
     pub fn text<const POS_DIM: usize>(&mut self, text: TextParams<'_, POS_DIM>) {
         let buf = self.rend.text_pl.create_buffer(text);
-        self.rend.text_pl.draw(self.ctx, self.camera, &[&buf]);
+        self.rend.text_pl.draw(self.ctx, self.camera, &[buf]);
+    }
+
+    /// Draw a slice of pre-created text buffers.
+    fn cached_text(&mut self, bufs: &[text::TextBuffer]) {
+        self.rend.text_pl.draw(self.ctx, self.camera, bufs);
     }
 }
 

--- a/crates/dexterior-visuals/src/pipelines/axes.rs
+++ b/crates/dexterior-visuals/src/pipelines/axes.rs
@@ -1,4 +1,12 @@
-use crate::{pipelines::LineDrawingMode, CapStyle, CapsStyle, LineParams, LineWidth};
+use crate::{
+    pipelines::{
+        text::{TextAnchor, TextBuffer, TextParams},
+        LineDrawingMode,
+    },
+    CapStyle, CapsStyle, LineParams, LineWidth,
+};
+
+use nalgebra as na;
 
 /// Parameters to configure the drawing of axis lines.
 #[derive(Clone, Copy, Debug)]
@@ -82,8 +90,9 @@ pub(crate) fn axes_2d(painter: &mut super::Painter, params: AxesParams) {
     let minor_tick_interval = params.tick_interval / (params.minor_ticks + 1) as f32;
     let minor_tick_halflength = params.tick_length * 0.75 / 2.;
 
-    let mut major_tick_points = Vec::new();
-    let mut minor_tick_points = Vec::new();
+    let mut major_tick_points: Vec<[f32; 3]> = Vec::new();
+    let mut minor_tick_points: Vec<[f32; 3]> = Vec::new();
+    let mut labels: Vec<TextBuffer> = Vec::new();
     // this should generalize to 3D fairly easily, I hope
     for axis_idx in 0..2 {
         let cross_axis_idx = (axis_idx + 1) % 2;
@@ -105,6 +114,24 @@ pub(crate) fn axes_2d(painter: &mut super::Painter, params: AxesParams) {
             tick_points[1][axis_idx] = major_coord;
             tick_points[1][cross_axis_idx] = origin[cross_axis_idx] - params.tick_length / 2.;
             major_tick_points.extend_from_slice(&tick_points);
+
+            labels.push(painter.rend.text_pl.create_buffer(TextParams {
+                text: &format!(" {major_coord:.1} "),
+                position: na::Vector3::new(
+                    tick_points[1][0] as f64,
+                    tick_points[1][1] as f64,
+                    tick_points[1][2] as f64,
+                ),
+                anchor: if axis_idx == 0 {
+                    TextAnchor::TopMid
+                } else {
+                    TextAnchor::MidRight
+                },
+                font_size: 16.,
+                line_height: 24.,
+                attrs: glyphon::Attrs::new().weight(glyphon::Weight::BOLD),
+                ..Default::default()
+            }));
 
             if major_idx == tick_count {
                 break;
@@ -132,4 +159,5 @@ pub(crate) fn axes_2d(painter: &mut super::Painter, params: AxesParams) {
         },
         &minor_tick_points,
     );
+    painter.cached_text(&labels);
 }

--- a/crates/dexterior-visuals/src/pipelines/axes.rs
+++ b/crates/dexterior-visuals/src/pipelines/axes.rs
@@ -151,6 +151,9 @@ pub(crate) fn axes_2d(painter: &mut super::Painter, params: AxesParams) {
         }
     }
 
+    // TODO: caching of lines like we cache text;
+    // only generate all of this once and store it until parameters change
+
     draw(params_proto, &major_tick_points);
     draw(
         LineParams {
@@ -159,5 +162,7 @@ pub(crate) fn axes_2d(painter: &mut super::Painter, params: AxesParams) {
         },
         &minor_tick_points,
     );
-    painter.cached_text(&labels);
+    for label in labels {
+        painter.cached_text(&label.cache());
+    }
 }

--- a/crates/dexterior-visuals/src/pipelines/text.rs
+++ b/crates/dexterior-visuals/src/pipelines/text.rs
@@ -15,14 +15,24 @@ pub(crate) struct TextPipeline {
     renderer: gh::TextRenderer,
 }
 
+/// Parameters for displaying text.
 #[derive(Clone, Copy, Debug)]
 pub struct TextParams<'a, const DIM: usize> {
+    /// Content of the text to be displayed. Default: "".
     pub text: &'a str,
+    /// Position of the anchor point in simulation space. Default: origin.
     pub position: na::SVector<f64, DIM>,
+    /// Placement of the anchor point relative to the text. Default: center.
     pub anchor: TextAnchor,
+    /// Fixed width for the text area in pixels. Default: None.
+    /// If not given, the text is laid out based on its own dimensions.
     pub area_width: Option<f32>,
+    /// Fixed height for the text area in pixels. Default: None.
+    /// If not given, the text is laid out based on its own dimensions.
     pub area_height: Option<f32>,
+    /// Font size of the text. Default: 30.0
     pub font_size: f32,
+    /// Line height of the text. Default: 42.0
     pub line_height: f32,
 }
 

--- a/crates/dexterior-visuals/src/pipelines/text.rs
+++ b/crates/dexterior-visuals/src/pipelines/text.rs
@@ -7,6 +7,8 @@ use crate::{
     render_window::{ActiveRenderWindow, RenderContext},
 };
 
+pub use gh::Color as TextColor;
+
 pub(crate) struct TextPipeline {
     font_system: gh::FontSystem,
     swash_cache: gh::SwashCache,
@@ -30,10 +32,12 @@ pub struct TextParams<'a, const DIM: usize> {
     /// Fixed height for the text area in pixels. Default: None.
     /// If not given, the text is laid out based on its own dimensions.
     pub area_height: Option<f32>,
-    /// Font size of the text. Default: 30.0
+    /// Font size of the text. Default: 30.
     pub font_size: f32,
-    /// Line height of the text. Default: 42.0
+    /// Line height of the text. Default: 42.
     pub line_height: f32,
+    /// Color of the text. Default: black.
+    pub color: TextColor,
 }
 
 impl<'a, const DIM: usize> Default for TextParams<'a, DIM> {
@@ -46,6 +50,7 @@ impl<'a, const DIM: usize> Default for TextParams<'a, DIM> {
             area_height: None,
             font_size: 30.,
             line_height: 42.,
+            color: TextColor::rgb(0, 0, 0),
         }
     }
 }
@@ -78,6 +83,7 @@ pub(crate) struct TextBuffer {
     buffer: gh::Buffer,
     position: na::Vector3<f32>,
     anchor: TextAnchor,
+    color: TextColor,
 }
 
 impl TextPipeline {
@@ -132,6 +138,7 @@ impl TextPipeline {
             buffer,
             position,
             anchor: params.anchor,
+            color: params.color,
         }
     }
 
@@ -204,8 +211,7 @@ impl TextPipeline {
                     right: (top_left_pixel.x + width + 1.) as i32,
                     bottom: (top_left_pixel.y + height + 1.) as i32,
                 },
-                // TODO configurable color
-                default_color: gh::Color::rgb(0, 0, 0),
+                default_color: buf.color,
                 custom_glyphs: &[],
             }
         });

--- a/crates/dexterior-visuals/src/pipelines/text.rs
+++ b/crates/dexterior-visuals/src/pipelines/text.rs
@@ -38,6 +38,11 @@ pub struct TextParams<'a, const DIM: usize> {
     pub line_height: f32,
     /// Color of the text. Default: black.
     pub color: TextColor,
+    /// Set of cosmic-text attributes for the text buffer.
+    /// Default: cosmic-text defaults with sans-serif font family.
+    ///
+    /// Types for the fields can be accessed through the library's re-export of [`glyphon`].
+    pub attrs: gh::Attrs<'a>,
 }
 
 impl<'a, const DIM: usize> Default for TextParams<'a, DIM> {
@@ -51,6 +56,7 @@ impl<'a, const DIM: usize> Default for TextParams<'a, DIM> {
             font_size: 30.,
             line_height: 42.,
             color: TextColor::rgb(0, 0, 0),
+            attrs: gh::Attrs::new().family(gh::Family::SansSerif),
         }
     }
 }
@@ -110,6 +116,8 @@ impl TextPipeline {
         }
     }
 
+    /// Create a renderable text buffer.
+    /// This can be cached if desired.
     pub fn create_buffer<const DIM: usize>(&mut self, params: TextParams<'_, DIM>) -> TextBuffer {
         let mut buffer = gh::Buffer::new(
             &mut self.font_system,
@@ -123,7 +131,7 @@ impl TextPipeline {
         buffer.set_text(
             &mut self.font_system,
             params.text,
-            gh::Attrs::new().family(gh::Family::SansSerif),
+            params.attrs,
             gh::Shaping::Advanced,
         );
         buffer.shape_until_scroll(&mut self.font_system, false);
@@ -142,6 +150,7 @@ impl TextPipeline {
         }
     }
 
+    /// Draw a slice of text areas in one draw call.
     pub fn draw(&mut self, ctx: &mut RenderContext, camera: &Camera, buffers: &[&TextBuffer]) {
         self.viewport.update(
             ctx.queue,

--- a/crates/dexterior-visuals/src/pipelines/text.rs
+++ b/crates/dexterior-visuals/src/pipelines/text.rs
@@ -1,0 +1,220 @@
+use glyphon as gh;
+use itertools::izip;
+use nalgebra as na;
+
+use crate::{
+    camera::Camera,
+    render_window::{ActiveRenderWindow, RenderContext},
+};
+
+pub(crate) struct TextPipeline {
+    font_system: gh::FontSystem,
+    swash_cache: gh::SwashCache,
+    viewport: gh::Viewport,
+    atlas: gh::TextAtlas,
+    renderer: gh::TextRenderer,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TextParams<'a, const DIM: usize> {
+    pub text: &'a str,
+    pub position: na::SVector<f64, DIM>,
+    pub anchor: TextAnchor,
+    pub area_width: Option<f32>,
+    pub area_height: Option<f32>,
+    pub font_size: f32,
+    pub line_height: f32,
+}
+
+impl<'a, const DIM: usize> Default for TextParams<'a, DIM> {
+    fn default() -> Self {
+        Self {
+            text: "",
+            position: na::SVector::zeros(),
+            anchor: TextAnchor::Center,
+            area_width: None,
+            area_height: None,
+            font_size: 30.,
+            line_height: 42.,
+        }
+    }
+}
+
+/// Where to place a text field
+/// relative to the position given in [`TextParams`].
+///
+/// For example, with an anchor of `TopMid`, the text will be placed
+/// relative to position `x` as follows:
+/// ```text
+/// ----x----
+/// |content|
+/// ---------
+/// ```
+#[derive(Clone, Copy, Debug)]
+#[allow(missing_docs)]
+pub enum TextAnchor {
+    TopLeft,
+    TopMid,
+    TopRight,
+    MidLeft,
+    Center,
+    MidRight,
+    BottomLeft,
+    BottomMid,
+    BottomRight,
+}
+
+pub(crate) struct TextBuffer {
+    buffer: gh::Buffer,
+    position: na::Vector3<f32>,
+    anchor: TextAnchor,
+}
+
+impl TextPipeline {
+    pub fn new(window: &ActiveRenderWindow) -> Self {
+        let font_system = gh::FontSystem::new();
+        let swash_cache = gh::SwashCache::new();
+        let cache = gh::Cache::new(&window.device);
+        let viewport = gh::Viewport::new(&window.device, &cache);
+        let mut atlas = gh::TextAtlas::new(
+            &window.device,
+            &window.queue,
+            &cache,
+            window.swapchain_format(),
+        );
+        let renderer =
+            gh::TextRenderer::new(&mut atlas, &window.device, window.multisample_state(), None);
+
+        Self {
+            font_system,
+            swash_cache,
+            viewport,
+            atlas,
+            renderer,
+        }
+    }
+
+    pub fn create_buffer<const DIM: usize>(&mut self, params: TextParams<'_, DIM>) -> TextBuffer {
+        let mut buffer = gh::Buffer::new(
+            &mut self.font_system,
+            gh::Metrics {
+                font_size: params.font_size,
+                line_height: params.line_height,
+            },
+        );
+
+        buffer.set_size(&mut self.font_system, params.area_width, params.area_height);
+        buffer.set_text(
+            &mut self.font_system,
+            params.text,
+            gh::Attrs::new().family(gh::Family::SansSerif),
+            gh::Shaping::Advanced,
+        );
+        buffer.shape_until_scroll(&mut self.font_system, false);
+
+        // embed/project the position to 3D space for rendering
+        let mut position = na::Vector3::zeros();
+        for (param_c, c) in izip!(params.position.iter(), position.iter_mut()) {
+            *c = *param_c as f32;
+        }
+
+        TextBuffer {
+            buffer,
+            position,
+            anchor: params.anchor,
+        }
+    }
+
+    pub fn draw(&mut self, ctx: &mut RenderContext, camera: &Camera, buffers: &[&TextBuffer]) {
+        self.viewport.update(
+            ctx.queue,
+            gh::Resolution {
+                width: ctx.viewport_size.0,
+                height: ctx.viewport_size.1,
+            },
+        );
+
+        let view_proj = camera.view_projection_matrix(ctx.viewport_size);
+        let half_vp = (
+            ctx.viewport_size.0 as f32 / 2.,
+            ctx.viewport_size.1 as f32 / 2.,
+        );
+
+        let areas = buffers.iter().map(|buf| {
+            let anchor_pos_ndc =
+                view_proj * na::Vector4::new(buf.position.x, buf.position.y, buf.position.z, 1.);
+            let anchor_pixel = na::Vector2::new(
+                anchor_pos_ndc.x * half_vp.0 + half_vp.0,
+                -anchor_pos_ndc.y * half_vp.1 + half_vp.1,
+            );
+
+            let (width, height) = buf.buffer.size();
+            let width = match width {
+                Some(w) => w,
+                // no explicit width given, compute from layout
+                None => buf
+                    .buffer
+                    .layout_runs()
+                    .map(|l| l.line_w)
+                    .max_by(f32::total_cmp)
+                    .unwrap_or(0.),
+            };
+            let height = match height {
+                Some(h) => h,
+                None => buf
+                    .buffer
+                    .layout_runs()
+                    .last()
+                    .map(|l| l.line_top + l.line_height)
+                    .unwrap_or(0.),
+            };
+
+            use TextAnchor::*;
+            let top_left_pixel = anchor_pixel
+                - match buf.anchor {
+                    TopLeft => na::Vector2::zeros(),
+                    TopMid => na::Vector2::new(width / 2., 0.),
+                    TopRight => na::Vector2::new(width, 0.),
+                    MidLeft => na::Vector2::new(0., height / 2.),
+                    Center => na::Vector2::new(width / 2., height / 2.),
+                    MidRight => na::Vector2::new(width, height / 2.),
+                    BottomLeft => na::Vector2::new(0., height),
+                    BottomMid => na::Vector2::new(width / 2., height),
+                    BottomRight => na::Vector2::new(width, height),
+                };
+
+            gh::TextArea {
+                buffer: &buf.buffer,
+                left: top_left_pixel.x,
+                top: top_left_pixel.y,
+                scale: 1.,
+                bounds: gh::TextBounds {
+                    left: top_left_pixel.x as i32,
+                    top: top_left_pixel.y as i32,
+                    right: (top_left_pixel.x + width + 1.) as i32,
+                    bottom: (top_left_pixel.y + height + 1.) as i32,
+                },
+                // TODO configurable color
+                default_color: gh::Color::rgb(0, 0, 0),
+                custom_glyphs: &[],
+            }
+        });
+
+        self.renderer
+            .prepare(
+                ctx.device,
+                ctx.queue,
+                &mut self.font_system,
+                &mut self.atlas,
+                &self.viewport,
+                areas,
+                &mut self.swash_cache,
+            )
+            .expect("Failed to render text");
+
+        let mut pass = ctx.pass("text");
+        self.renderer
+            .render(&self.atlas, &self.viewport, &mut pass)
+            .expect("Failed to render text");
+    }
+}

--- a/crates/dexterior-visuals/src/pipelines/text.rs
+++ b/crates/dexterior-visuals/src/pipelines/text.rs
@@ -151,7 +151,7 @@ impl TextPipeline {
     }
 
     /// Draw a slice of text areas in one draw call.
-    pub fn draw(&mut self, ctx: &mut RenderContext, camera: &Camera, buffers: &[&TextBuffer]) {
+    pub fn draw(&mut self, ctx: &mut RenderContext, camera: &Camera, buffers: &[TextBuffer]) {
         self.viewport.update(
             ctx.queue,
             gh::Resolution {

--- a/crates/dexterior-visuals/src/render_window.rs
+++ b/crates/dexterior-visuals/src/render_window.rs
@@ -583,7 +583,6 @@ where
             ctx: &mut ctx,
             rend: renderer,
             mesh: self.anim.mesh,
-            camera: &self.camera,
         };
 
         let interpolated_state = State::interpolate(
@@ -592,6 +591,7 @@ where
             self.time_in_frame / self.anim.dt,
         );
         (self.anim.draw)(&interpolated_state, &mut painter);
+        renderer.draw_batched(&mut ctx, &self.camera);
 
         ctx.queue.submit(Some(ctx.encoder.finish()));
         renderer.end_frame();

--- a/crates/dexterior-visuals/src/render_window.rs
+++ b/crates/dexterior-visuals/src/render_window.rs
@@ -583,6 +583,7 @@ where
             ctx: &mut ctx,
             rend: renderer,
             mesh: self.anim.mesh,
+            camera: &self.camera,
         };
 
         let interpolated_state = State::interpolate(

--- a/crates/dexterior/examples/membrane.rs
+++ b/crates/dexterior/examples/membrane.rs
@@ -89,14 +89,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             draw.velocity_arrows(&state.v, dv::ArrowParams::default());
             draw.axes_2d(dv::AxesParams::default());
 
-            // draw.text(dv::TextParams {
-            //     text: "test text\nχξΔ",
-            //     position: mesh.vertices()[2],
-            //     anchor: dv::TextAnchor::BottomMid,
-            //     color: dv::TextColor::rgb(150, 0, 0),
-            //     attrs: dv::glyphon::Attrs::new().style(dv::glyphon::Style::Italic),
-            //     ..Default::default()
-            // });
+            draw.text(dv::TextParams {
+                text: "test text\nχξΔ",
+                position: mesh.vertices()[2],
+                anchor: dv::TextAnchor::BottomMid,
+                color: dv::TextColor::rgb(150, 0, 0),
+                attrs: dv::glyphon::Attrs::new().style(dv::glyphon::Style::Italic),
+                ..Default::default()
+            });
         },
     })?;
 

--- a/crates/dexterior/examples/membrane.rs
+++ b/crates/dexterior/examples/membrane.rs
@@ -93,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 text: "test text\nχξΔ",
                 position: mesh.vertices()[2],
                 anchor: dv::TextAnchor::BottomMid,
+                color: dv::TextColor::rgb(150, 0, 0),
                 ..Default::default()
             });
         },

--- a/crates/dexterior/examples/membrane.rs
+++ b/crates/dexterior/examples/membrane.rs
@@ -89,14 +89,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             draw.velocity_arrows(&state.v, dv::ArrowParams::default());
             draw.axes_2d(dv::AxesParams::default());
 
-            draw.text(dv::TextParams {
-                text: "test text\nχξΔ",
-                position: mesh.vertices()[2],
-                anchor: dv::TextAnchor::BottomMid,
-                color: dv::TextColor::rgb(150, 0, 0),
-                attrs: dv::glyphon::Attrs::new().style(dv::glyphon::Style::Italic),
-                ..Default::default()
-            });
+            // draw.text(dv::TextParams {
+            //     text: "test text\nχξΔ",
+            //     position: mesh.vertices()[2],
+            //     anchor: dv::TextAnchor::BottomMid,
+            //     color: dv::TextColor::rgb(150, 0, 0),
+            //     attrs: dv::glyphon::Attrs::new().style(dv::glyphon::Style::Italic),
+            //     ..Default::default()
+            // });
         },
     })?;
 

--- a/crates/dexterior/examples/membrane.rs
+++ b/crates/dexterior/examples/membrane.rs
@@ -88,6 +88,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             draw.wireframe(dv::WireframeParams::default());
             draw.velocity_arrows(&state.v, dv::ArrowParams::default());
             draw.axes_2d(dv::AxesParams::default());
+
+            draw.text(dv::TextParams {
+                text: "test text\nχξΔ",
+                position: mesh.vertices()[2],
+                anchor: dv::TextAnchor::BottomMid,
+                ..Default::default()
+            });
         },
     })?;
 

--- a/crates/dexterior/examples/membrane.rs
+++ b/crates/dexterior/examples/membrane.rs
@@ -94,6 +94,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 position: mesh.vertices()[2],
                 anchor: dv::TextAnchor::BottomMid,
                 color: dv::TextColor::rgb(150, 0, 0),
+                attrs: dv::glyphon::Attrs::new().style(dv::glyphon::Style::Italic),
                 ..Default::default()
             });
         },


### PR DESCRIPTION
Adds an API for drawing text with `glyphon` and uses it internally to draw number labels on axis ticks.